### PR TITLE
chore deps(upgrade): upgrade protractor-typescript-cucumber deps

### DIFF
--- a/protractor-typescript-cucumber/package.json
+++ b/protractor-typescript-cucumber/package.json
@@ -19,24 +19,24 @@
   ],
   "main": "index.js",
   "scripts": {
-    "tsc": "./node_modules/typescript/bin/tsc",
-    "pretest": "webdriver-manager update && npm run tsc",
-    "test": "protractor tmp/Config/config.js"
+    "tsc": "tsc",
+    "pretest": "npm run tsc && webdriver-manager update",
+    "test": "protractor tmp/config/config.js"
   },
   "author": "Ram Pasala <ram.pasala7@gmail.com>",
   "devDependencies": {
     "@types/cucumber": "0.0.32",
-    "@types/node": "^6.0.40",
-    "@types/selenium-webdriver": "^2.53.30",
+    "@types/node": "^6.0.52",
+    "@types/selenium-webdriver": "^2.53.37",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "cucumber": "^1.2.2",
     "protractor-cucumber-framework": "^0.6.0"
   },
   "dependencies": {
-    "protractor": "^4.0.10",
-    "ts-node": "^1.3.0",
-    "typescript": "^2.0.0"
+    "protractor": "^4.0.14",
+    "ts-node": "^1.7.2",
+    "typescript": "^2.1.4"
   },
   "repository": {
     "type": "git",

--- a/protractor-typescript-cucumber/tsconfig.json
+++ b/protractor-typescript-cucumber/tsconfig.json
@@ -8,9 +8,11 @@
         "removeComments": false,
         "noImplicitAny": false,
         "outDir": "tmp",
+        "typeRoots": [ "./node_modules/@types" ],
         "types": ["node","cucumber"]
     },
     "exclude": [
-        "node_modules"
+        "node_modules",
+        "tmp"
     ]
 }


### PR DESCRIPTION
* Upgraded to latest protractor 4.0.14 & typescript 2.1.4
* Added `typeRoots` to tsconfig.json . Issues are being encountered with latest typescript if we don't specify @types location in typeRoots.